### PR TITLE
Remove incorrectly escaped url token in RestSharp route.

### DIFF
--- a/src/StripeClient.Cards.cs
+++ b/src/StripeClient.Cards.cs
@@ -104,7 +104,7 @@ namespace Stripe
 
             var request = new RestRequest();
             request.Method = Method.POST;
-            request.Resource = "customers/{{customerId}}/cards";
+            request.Resource = "customers/{customerId}/cards";
 
             request.AddUrlSegment("customerId", customerId);
             request.AddParameter("card", cardToken);


### PR DESCRIPTION
Well, damn. There was one overzealous escaping in the previous PR. This fixes that.
